### PR TITLE
Add heuristic for tunnel type.

### DIFF
--- a/modules/provider/hopglass.js
+++ b/modules/provider/hopglass.js
@@ -136,11 +136,26 @@ module.exports = function(receiver, config) {
                 var tq = _.get(n, ['neighbours', 'batadv', dest, 'neighbours', src, 'tq'])
                 link.tq = 255 / (tq ? tq : 1)
 
-                if (typeTable[src] === 'l2tp')
+                var ts = typeTable[src], td = typeTable[dest]
+                if (ts === 'l2tp' || td === 'l2tp') {
                   link.type = 'l2tp'
-                else if (typeTable[dest] === 'tunnel')
+                } else if (ts === 'fastd' || td === 'fastd') {
                   link.type = 'fastd'
-                else
+                } else if (ts === 'tunnel' || td === 'tunnel') {
+                  link.type = 'tunnel';
+
+                  if (td === 'tunnel' && (ts == undefined || ts === 'tunnel')) {
+                    var fds = 0, tds = 0, sis = 0
+                    if (_.get(data[macTable[dest]], 'nodeinfo.software.fastd.enabled', false)) fds++
+                    if (_.get(data[macTable[src]], 'nodeinfo.software.fastd.enabled', false)) fds++
+                    if (_.get(data[macTable[dest]], 'nodeinfo.software.tunneldigger.enabled', false)) tds++
+                    if (_.get(data[macTable[src]], 'nodeinfo.software.tunneldigger.enabled', false)) tds++
+                    if (_.has(data[macTable[dest]], 'nodeinfo.software')) sis++
+                    if (_.has(data[macTable[src]], 'nodeinfo.software')) sis++
+                    if (sis == fds && fds > 0) link.type = 'fastd'
+                    if (sis == tds && tds > 0) link.type = 'l2tp'
+                  }
+                } else
                   link.type = typeTable[dest]
 
                 if (isNaN(link.source)) {


### PR DESCRIPTION
Not all tunnels are fastd, non-gluon firmware also uses several others, e.g. openvpn

This guesses a tunnel to be l2tp/fastd if both ends have l2tp/fastd enabled (if only one end provides data, that's fine as well). If not, we go with legacy "tunnel" value.
It also assumes sth to be a l2tp/fastd tunnel, if at least one side announces it directly as its link type. This means you can always override using the aliases.json or respondd server on the gateway.