### PR TITLE
prometheus: Count clients on an online node with missing statistics packet

### DIFF
--- a/modules/provider/prometheus-metrics.js
+++ b/modules/provider/prometheus-metrics.js
@@ -116,9 +116,11 @@ module.exports = function(receiver, config) {
 
       delete labels['firmware']
 
-      if (isOnline(n, 'statistics')) {
+      if (isOnline(n)) {
         counter.clients += get(n, 'statistics.clients.total')
+      }
 
+      if (isOnline(n, 'statistics')) {
         save(n, stream, labels, 'statistics.clients.total')
         save(n, stream, labels, 'statistics.uptime')
         save(n, stream, labels, 'statistics.loadavg')


### PR DESCRIPTION
The current implementation would cause the total count to be jumping up/down when nodes have unstable network conditions

This reflects the same value as displayed in hopglass