### PR TITLE
isOnline statistics for counting clients

### DIFF
--- a/modules/provider/prometheus-metrics.js
+++ b/modules/provider/prometheus-metrics.js
@@ -117,10 +117,6 @@ module.exports = function(receiver, config) {
 
       delete labels['firmware']
 
-      if (isOnline(n)) {
-        counter.clients += get(n, 'statistics.clients.total')
-      }
-
       if (isOnline(n, 'statistics')) {
         save(n, stream, labels, 'statistics.clients.total')
         save(n, stream, labels, 'statistics.uptime')
@@ -129,6 +125,8 @@ module.exports = function(receiver, config) {
 
         if (_.has(n, 'statistics.memory.free') && _.has(n, 'statistics.memory.total'))
           save(n, stream, labels, 'statistics_memory_usage', null, (n.statistics.memory.total - n.statistics.memory.free) / n.statistics.memory.total)
+
+        counter.clients += get(n, 'statistics.clients.total')
 
         labels['mtype'] = 'user'
         labels['type'] = 'forward'


### PR DESCRIPTION
continued from #45 

I just noticed that it IS a big deal if we use
`if (isOnline(n)) { counter.clients += get(n, 'statistics.clients.total') }`

or

`if (isOnline(n, 'statistics')) { counter.clients += get(n, 'statistics.clients.total') }`

I get values which differ by round about 700 (~150 to ~850), although I set metricsOfflineTime and offlineTime to the same value.

Can you explain why? What is correct here?

Thank you in advance!