### PR TITLE
Defer `retrieve('statistics')` to avoid buffer overruns and packetloss

### DIFF
--- a/modules/receiver/announced.js
+++ b/modules/receiver/announced.js
@@ -96,6 +96,8 @@ module.exports = function(receiverId, configData, api) {
 
   setInterval(function() {
     retrieve('neighbours')
-    retrieve('statistics')
+    setTimeout(function() {
+      retrieve('statistics')
+    }, 6000);
   }, config.interval.statistics * 1000)
 }


### PR DESCRIPTION
When running in a larger mesh nodes might not respond to the statistics request when queries immediately after neighbors.
There are at least two known issues with larger meshes with the default configuration:

* recv_mem buffer it not sufficient per default causing replies to be dropped (on the hopglass server)
* nodes in the mesh might not relay requests for yet unknown reason (tested with B.A.T.M.A.N >=2016.2) when both queries arrive immediatly