### PR TITLE
Update bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,10 +12,10 @@ function ask_user {
     echo
     echo 'Your system is not supported.'
     exit 2
-  elif ! pidof systemd >/dev/null
+  elif [ ! -d "/usr/lib/systemd" ]
   then
     echo
-    echo 'Your system does not run systemd. It is only partitially supported. '
+    echo 'Your system does not use systemd. It is only partitially supported. '
     echo 'Do you want to continue? [y/N]'
     read CONTINUE
     if [ "$CONTINUE" == "y" ]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,7 +12,7 @@ function ask_user {
     echo
     echo 'Your system is not supported.'
     exit 2
-  elif [ ! -d "/usr/lib/systemd" ]
+  elif ! readlink -f /sbin/init | grep -q "systemd"
   then
     echo
     echo 'Your system does not use systemd. It is only partitially supported. '
@@ -116,7 +116,7 @@ EOF
 
   #Symlink systemd service and copy config file:
   #only for systemd-systems
-  if [ -d "/usr/lib/systemd" ]
+  if readlink -f /sbin/init | grep -q "systemd"
   then
     mkdir -p /etc/hopglass-server/default
     cp $INSTALL_DIR/server/config.json.example /etc/hopglass-server/default/config.json

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -116,7 +116,7 @@ EOF
 
   #Symlink systemd service and copy config file:
   #only for systemd-systems
-  if pidof systemd >/dev/null
+  if [ -d "/usr/lib/systemd" ]
   then
     mkdir -p /etc/hopglass-server/default
     cp $INSTALL_DIR/server/config.json.example /etc/hopglass-server/default/config.json


### PR DESCRIPTION
`pidof systemd` doesn't return a value on Debian systems, even though systemd is running. Therefore a check if `/usr/lib/systemd` exists in order to detect if the system uses systemd would be better I think.