### PR TITLE
Removed gateway label from prometheus metrics. 

### DIFF
--- a/config.json.defaults
+++ b/config.json.defaults
@@ -15,6 +15,19 @@
         },
         "overlay": false
       },
+      { "module": "alfred",
+        "config": {
+          "alfred_json": "/usr/bin/alfred-json",
+          "sockets": [
+            "/var/run/alfred-bat0.sock"
+          ],
+          "interval": {
+            "statistics": 60,
+            "nodeinfo": 500
+          }
+        },
+        "overlay": false
+      },
       { "module": "aliases",
         "config": {
           "file": "./aliases.json"

--- a/config.json.example
+++ b/config.json.example
@@ -9,6 +9,18 @@
           }
         }
       },
+      { "module": "alfred",
+        "alfred_json": "/usr/bin/alfred-json",
+        "sockets": [
+          "/var/run/alfred-bat0.sock"
+        ],
+        "config": {
+          "interval": {
+            "statistics": 60,
+            "nodeinfo": 500
+          }
+        }
+      },
       { "module": "aliases",
         "config": {
           "file": "./aliases.json"

--- a/modules/provider/prometheus-metrics.js
+++ b/modules/provider/prometheus-metrics.js
@@ -107,9 +107,6 @@ module.exports = function(receiver, config) {
       if (_.has(n, 'nodeinfo.hostname'))
         labels['hostname'] = _.get(n, 'nodeinfo.hostname')
 
-      if (isOnline(n, 'statistics') && _.has(n, 'statistics.gateway'))
-        labels['gateway'] = _.get(n, 'statistics.gateway')
-
       if (_.has(n, 'nodeinfo.system.site_code'))
         labels['site'] = _.get(n, 'nodeinfo.system.site_code')
 

--- a/modules/receiver.js
+++ b/modules/receiver.js
@@ -24,6 +24,7 @@ var config = {
   /* eslint-disable quotes */
   receivers: [
     { module: "announced" },
+    { module: "alfred" },
     { module: "aliases",
       overlay: true
     }

--- a/modules/receiver/alfred.js
+++ b/modules/receiver/alfred.js
@@ -1,0 +1,77 @@
+/*  Copyright (C) 2017 Linus Broich
+    Copyright (C) 2016 HopGlass Server contributors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+/*  Hacky alfred receiver v 0.1,
+    uses alfred-json for now ;) 
+    See: https://github.com/ffnord/alfred-json */
+'use strict'
+
+var exec = require('sync-exec');
+var _ = require('lodash')
+
+var config = {
+  /* eslint-disable quotes */
+  "alfred_json": "/usr/bin/alfred-json",
+  "sockets": [
+    "/var/run/alfred-bat0.sock"
+  ],
+  "interval": {
+    "statistics": 60,
+    "nodeinfo": 500
+  }
+}
+
+delete require.cache[__filename]
+
+module.exports = function(receiverId, configData, api) {
+  _.merge(config, configData)
+  
+  function retrieve(stat) {
+    var type
+    if (stat == 'nodeinfo') {
+      type = 158
+    } else if (stat == 'statistics') {
+      type = 159
+    } else if (stat == 'neighbours') {
+      type = 160
+    } else return
+    config.sockets.forEach(function(socket) {
+      /* We should read the data directly from the socket instead of using alfred-json...*/
+      var result = exec(config.alfred_json + ' -zr ' + type + ' -s ' + socket)
+      var jsondata = JSON.parse(result.stdout)
+      Object.keys(jsondata).forEach(function(key) {
+        var obj = {}
+        obj[stat] = jsondata[key]
+        var id = obj[stat].node_id
+        api.receiverCallback(id, obj, receiverId)
+      })
+    })
+  }
+  
+  console.log('Hacky alfred receiver starting...')
+  retrieve('nodeinfo')
+  retrieve('neighbours')
+  retrieve('statistics')
+
+  setInterval(function() {
+    retrieve('nodeinfo')
+  }, config.interval.nodeinfo * 1000)
+
+  setInterval(function() {
+    retrieve('neighbours')
+    retrieve('statistics')
+  }, config.interval.statistics * 1000)
+}


### PR DESCRIPTION
This breaks graphs and is against best practices. Labels should not be used for values
with high cardinality or unbound sets of values.

Read: https://prometheus.io/docs/practices/naming/