### PR TITLE
Removed gateway label from all but the "online" metric. [New PR due to github issue]

### DIFF
--- a/modules/provider/prometheus-metrics.js
+++ b/modules/provider/prometheus-metrics.js
@@ -118,6 +118,7 @@ module.exports = function(receiver, config) {
 
       save(n, stream, labels, null, 'online', isOnline(n) ? 1 : 0)
 
+      delete labels['gateway']
       delete labels['firmware']
 
       if (isOnline(n)) {


### PR DESCRIPTION
This breaks graphs and is against best practices. Labels should not be used for values
with high cardinality or unbound sets of values.

Read: https://prometheus.io/docs/practices/naming/