### PR TITLE
Fixed filterData function.

### DIFF
--- a/modules/receiver.js
+++ b/modules/receiver.js
@@ -123,15 +123,15 @@ module.exports = function (configData) {
     // filtern anhand der übergebenen Filterwerte
     switch (query.filter) {
     case 'site':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         return _.get(o, 'nodeinfo.system.site_code', 'unknown') === query.value ? true : false
       })
     case 'firmware_release':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         return _.get(o, 'nodeinfo.software.firmware.release', 'unknown') === query.value ? true : false
       })
     case 'firstseen':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         var firstseen = (new Date(o.firstseen)).getTime()
         var now = (new Date()).getTime()
         var v = parseInt(query.value)*1000
@@ -142,7 +142,7 @@ module.exports = function (configData) {
         }
       })
     case 'lastseen':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         var lastseen = (new Date(o.lastseen)).getTime()
         var now = (new Date()).getTime()
         var v = parseInt(query.value)*1000
@@ -153,7 +153,7 @@ module.exports = function (configData) {
         }
       })
     case 'uptime':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         var uptime = parseInt(_.get(o, 'statistics.uptime', '-1'))
         var v = parseInt(query.value)
         if (v >= 0) {
@@ -163,7 +163,7 @@ module.exports = function (configData) {
         }
       })
     case 'clients':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         var clients = parseInt(_.get(o, 'statistics.clients.total', '-1'))
         var v = parseInt(query.value)
         if (v >= 0) {
@@ -173,7 +173,7 @@ module.exports = function (configData) {
         }
       })
     case 'nodeid':
-      return _.filter(data, function(o) {
+      return _.pickBy(data, function(o) {
         return _.get(o, 'nodeinfo.node_id') == query.value
       })
     default:


### PR DESCRIPTION
 Input object was converted from object to array before. That caused a broken graph view if graph.json (and nodes.json) were filtered.

As [lodash doc](https://lodash.com/docs/4.17.4#filter) ``tells _.filter()`` will take an object or an array and returns an array. In case of hopglass-server there will converted an object to an array. This will break the graph view in the hopglass frontend because the node_id is determined by the (top level) object keys.

Example (truncated and anonymized):

Unfiltered graph.json:

```json
{
  "timestamp": "2017-03-04T22:34:42.436Z",
  "version": 1,
  "batadv": {
    "multigraph": false,
    "directed": true,
    "nodes": [
      {
        "id": "02:ca:ff:xx:xx:xx",
        "node_id": "7acd5bxxxxxx"
      },
      {
        "id": "c6:91:56:xx:xx:xx",
        "node_id": "ec086bxxxxxx"
      },
      {
        "id": "02:ca:ff:xx:xx:xx",
        "node_id": "76d4fbxxxxxx"
      },
      {
        "id": "4a:31:74:xx:xx:xx",
        "node_id": "60e327xxxxxx"
      },
      {
        "id": "aa:f6:44:xx:xx:xx",
        "node_id": "60e327xxxxxx"
      },
      {
        "id": "b6:61:96:xx:xx:xx",
        "node_id": "60e327xxxxxx"
      },
      {
        "id": "66:0c:02:xx:xx:xx",
        "node_id": "60e327xxxxxx"
      },
      {
        "id": "fe:01:21:xx:xx:xx",
      ...
```

Filtered graph.json (by site code):

```json
{
  "timestamp": "2017-03-04T22:33:58.060Z",
  "version": 1,
  "batadv": {
    "multigraph": false,
    "directed": true,
    "nodes": [
      {
        "id": "02:ca:ff:xx:xx:xx",
        "node_id": 316
      },
      {
        "id": "c6:91:56:xx:xx:xx",
        "node_id": 1
      },
      {
        "id": "02:ca:ff:xx:xx:xx",
        "node_id": 314
      },
      {
        "id": "4a:31:74:xx:xx:xx",
        "node_id": 2
      },
      {
        "id": "aa:f6:44:xx:xx:xx",
        "node_id": 8
      },
      {
        "id": "b6:61:96:xx:xx:xx",
        "node_id": 6
      },
      {
        "id": "66:0c:02:xx:xx:xx",
        "node_id": 5
      }
      ...
```

So ``_.pickBy()`` should used instead because it does the same except it requires an object **and** [returns an object](https://lodash.com/docs/4.17.4#pickBy).