### PR TITLE
Add hardware model to Prometheus metrics

### DIFF
--- a/modules/provider/prometheus-metrics.js
+++ b/modules/provider/prometheus-metrics.js
@@ -116,6 +116,9 @@ module.exports = function(receiver, config) {
       if (_.has(n, 'nodeinfo.software.firmware.release'))
         labels['firmware'] = _.get(n, 'nodeinfo.software.firmware.release')
 
+      if (_.has(n, 'nodeinfo.hardware.model'))
+        labels['model'] = _.get(n, 'nodeinfo.hardware.model')
+
       save(n, stream, labels, null, 'online', isOnline(n) ? 1 : 0)
 
       delete labels['gateway']


### PR DESCRIPTION
It is useful to have the model name in the prometheus data
since it can help tracking down systemic issues with certain
router models