### PR TITLE
ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ aliases.json
 config.json
 hosts
 node_modules
+package-lock.json


### PR DESCRIPTION
npm install will generate the lock file, when on build server or deployment server