### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Note: The default paths for configuration and state files might have changed. Ma
 
 ## Metrics values
 
-### per node (all with the labels `hostname`, `nodeid` and `gateway`):
+### per node (all with the labels `hostname`, and `nodeid`):
 
 - statistics.clients.total
 - statistics.uptime


### PR DESCRIPTION
Cc https://github.com/hopglass/hopglass-server/issues/116

However, the `online` metric that still has the gateway info probably also should be mentioned somewhere. I just was not sure where?