### PR TITLE
Ensure sending is finished before switching interface

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
         "node": true
     },
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 8,
+    },
     "rules": {
         "no-console": [
             "off"

--- a/modules/receiver/announced.js
+++ b/modules/receiver/announced.js
@@ -72,15 +72,18 @@ module.exports = function(receiverId, configData, api) {
     })
   })
 
-  function retrieve(stat, address) {
+  async function retrieve(stat, address) {
     const ip = address ? address : config.target.ip
     const req = Buffer.from('GET ' + stat)
-    api.sharedConfig.ifaces.forEach(function(iface) {
-      collector.setMulticastInterface(ip + '%' + iface)
-      collector.send(req, 0, req.length, config.target.port, ip + '%' + iface, function (err) {
-        if (err) console.error(err)
+    for (const iface of api.sharedConfig.ifaces) {
+      await new Promise((resume) => {
+        collector.setMulticastInterface(ip + '%' + iface)
+        collector.send(req, 0, req.length, config.target.port, ip + '%' + iface, function (err) {
+          if (err) console.error(err)
+          resume()
+        })
       })
-    })
+    }
   }
 
   collector.on('listening', function() {


### PR DESCRIPTION
The old code had issues (at least with some node.js version) because `collector.setMulticastInterface()` was invoked before `collector.send()` finished, causing the request to be send on the wrong interface in multi-interface setups.